### PR TITLE
Update table row theme to be same size as paragraph text

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 version 0.0.3dev
 ----------------
+- updated the table row theme to have same text size as paragraphs (PR #10)
 
 version 0.0.2
 -------------

--- a/stsci_rtd_theme/static/stsci.css
+++ b/stsci_rtd_theme/static/stsci.css
@@ -4422,7 +4422,13 @@ input[type="checkbox"][disabled] {
 }
 
 .wy-table td,
-.rst-content table.docutils td,
+.rst-content table.docutils td{
+    font-size: 16px;
+    text-align: middle;
+    overflow: visible;
+    padding: 8px 16px
+}
+
 .rst-content table.field-list td,
 .wy-table th,
 .rst-content table.docutils th,


### PR DESCRIPTION
I updated the table td elements to make text in table rows the same size and formatting as paragraph text.  @hbushouse install this PR then remake the jwst docs and see what you think. Let me know if it's what you expected, or if you'd like any other changes.