### PR TITLE
MNT: Add sphinx-rtd-theme as dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-import os
 from setuptools import setup
 
 setup(
@@ -31,5 +30,5 @@ setup(
         'Topic :: Documentation',
         'Topic :: Software Development :: Documentation',
     ],
-    install_requires=('sphinx>=1.3', ),
+    install_requires=('sphinx>=1.3', 'sphinx-rtd-theme'),
 )


### PR DESCRIPTION
To avoid error like:
```
Theme error:
no theme named 'sphinx_rtd_theme' found, inherited by 'stsci_rtd_theme'
make: *** [Makefile:34: html] Error 2
```