### PR TITLE
add exact version in sidebar

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
-version 0.0.3dev
+version 0.0.3
 ----------------
 - updated the table row theme to have same text size as paragraphs (PR #10)
+- added exact version to navigation bar - if 'stable', the last released version will show, and 'latest' will reference the last commit [#16]
 
 version 0.0.2
 -------------

--- a/stsci_rtd_theme/layout.html
+++ b/stsci_rtd_theme/layout.html
@@ -12,7 +12,19 @@
             {% endif %}
             {% if nav_version %}
               <div class="version">
-                {{ nav_version }}
+                {% if nav_version == "stable" %}
+                    stable version
+                    {% if version and version != "stable" %}
+                        <small>({{ version }})</small>
+                    {% endif %}
+                {% elif nav_version == "latest" %}
+                    development version
+                    {% if commit %}
+                        <small>(<tt>{{ commit }}</tt>)</small>
+                    {% endif %}
+                {% else %}
+                    version {{ nav_version }}
+                {% endif %}
               </div>
             {% endif %}
           {% endif %}


### PR DESCRIPTION
Documentation will now display the exact version in the left navigation bar. If you're looking at the 'stable' version, it will be the last release, and if you are looking at 'latest', it will reference the last commit.

Closes [#5673](https://github.com/spacetelescope/jwst/issues/5673)