### PR TITLE
SCSB-46: move build configuration into `pyproject.toml` and `setup.cfg`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: build
 
-on: [ push ]
+on: [ push, pull_request ]
 
 jobs:
   build:
@@ -11,8 +11,8 @@ jobs:
         os: [ ubuntu-latest, macos-latest ]
         python: [ 3.8, 3.9, '3.10' ]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
       - uses: actions/cache@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,22 @@
+name: build
+
+on: [ push ]
+
+jobs:
+  build:
+    name: build package
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+        python: [ 3.8, 3.9, '3.10' ]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+      - uses: actions/cache@v3
+        with:
+          path: ${{ env.pythonLocation }}
+          key: build-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('**/pyproject.toml', '**/setup.*') }}
+      - run: pip wheel .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,48 @@
+[project]
+name = 'stsci-rtd-theme'
+description = 'STScI Branded Sphinx theme'
+readme = 'README.md'
+requires-python = '>=3.8'
+license = { file = 'LICENSE' }
+authors = [{ name = 'STScI', email = 'help@stsci.edu' }]
+classifiers = [
+    'Development Status :: 5 - Production/Stable',
+    'License :: OSI Approved :: BSD License',
+    'Programming Language :: Python :: 2.7',
+    'Programming Language :: Python :: 3',
+    'Operating System :: OS Independent',
+    'Topic :: Documentation',
+    'Topic :: Software Development :: Documentation',
+]
+dependencies = [
+    'sphinx>=1.3',
+    'sphinx-rtd-theme',
+]
+dynamic = ['version']
+
+[project.urls]
+'repository' = 'https://github.com/spacetelescope/stsci_rtd_theme'
+
+[project.entry-points]
+'sphinx.html_themes' = { stsci_rtd_theme = 'stsci_rtd_theme' }
+
+[build-system]
+requires = [
+    'setuptools >=61',
+    'setuptools_scm[toml] >=3.4',
+    'wheel',
+]
+build-backend = 'setuptools.build_meta'
+
+[tool.setuptools_scm]
+
+[tool.setuptools]
+zip-safe = false
+packages = ['stsci_rtd_theme']
+
+[tool.setuptools.package-data]
+'stsci_rtd_theme' = [
+    'theme.conf',
+    'static/*',
+    '*.html'
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,9 +36,6 @@ build-backend = 'setuptools.build_meta'
 
 [tool.setuptools_scm]
 
-[tool.setuptools]
-zip_safe = false
-
 [tool.setuptools.packages.find]
 
 [tool.setuptools.package-data]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,16 +33,3 @@ requires = [
     'wheel',
 ]
 build-backend = 'setuptools.build_meta'
-
-[tool.setuptools_scm]
-
-[tool.setuptools]
-zip-safe = false
-packages = ['stsci_rtd_theme']
-
-[tool.setuptools.package-data]
-'stsci_rtd_theme' = [
-    'theme.conf',
-    'static/*',
-    '*.html'
-]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,3 +33,13 @@ requires = [
     'wheel',
 ]
 build-backend = 'setuptools.build_meta'
+
+[tool.setuptools_scm]
+
+[tool.setuptools]
+zip_safe = false
+
+[tool.setuptools.packages.find]
+
+[tool.setuptools.package-data]
+stsci_rtd_theme = ['theme.conf', 'static/*', '*.html']

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,0 @@
-[options]
-zip_safe = False
-packages = stsci_rtd_theme
-
-[options.package_data]
-stsci_rtd_theme = theme.conf, static/*, *.html

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,6 @@
+[options]
+zip_safe = False
+packages = stsci_rtd_theme
+
+[options.package_data]
+stsci_rtd_theme = theme.conf, static/*, *.html

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,0 @@
-from setuptools import setup
-
-setup(use_scm_version=True)

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,3 @@
 from setuptools import setup
 
-setup()
+setup(use_scm_version=True)

--- a/setup.py
+++ b/setup.py
@@ -1,34 +1,3 @@
 from setuptools import setup
 
-setup(
-    name='stsci_rtd_theme',
-    version='1.0.0',
-    author='STScI',
-    author_email='help@stsci.edu',
-    description='STScI Branded Sphinx theme',
-    zip_safe=False,
-    packages=['stsci_rtd_theme'],
-    package_data={'stsci_rtd_theme': [
-                 'theme.conf',
-                 'static/*',
-                 '*.html'
-    ]},
-    include_package_data=True,
-    url='https://github.com/spacetelescope/stsci_rtd_theme/',
-    license='BSD',
-    entry_points={
-        'sphinx.html_themes': [
-            'stsci_rtd_theme = stsci_rtd_theme',
-        ],
-    },
-    classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'License :: OSI Approved :: BSD License',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Operating System :: OS Independent',
-        'Topic :: Documentation',
-        'Topic :: Software Development :: Documentation',
-    ],
-    install_requires=('sphinx>=1.3', 'sphinx-rtd-theme'),
-)
+setup()


### PR DESCRIPTION
Resolves [SCSB-46](https://jira.stsci.edu/browse/SCSB-46)

moved project metadata into `pyproject.toml` in alignment with [PEP621](https://peps.python.org/pep-0621), and `setuptools`-specific options into `setup.cfg` (as `setuptools` options support for `pyproject.toml` is still experimental)

Additionally, this change makes use of `setuptools_scm` for dynamic versioning based on tag